### PR TITLE
Add Purple VC

### DIFF
--- a/DuplicateCodeDemo/PurpleVC.swift
+++ b/DuplicateCodeDemo/PurpleVC.swift
@@ -1,0 +1,28 @@
+//
+//  PurpleVC.swift
+//  DuplicateCodeDemo
+//
+//  Created by Abd Sani Abd Jalal on 23/04/2025.
+//
+
+import UIKit
+
+class PurpleVC: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.view.backgroundColor = .purple
+
+        // Do any additional setup after loading the view.
+    }
+    
+    @objc func goToMainView() {
+        let redViewController2 = RedViewController2()
+        self.navigationController?.pushViewController(redViewController2, animated: true)
+    }
+    
+    @objc func goToFirstView() {
+        let redViewController2 = RedViewController2()
+        self.navigationController?.pushViewController(redViewController2, animated: true)
+    }
+}

--- a/DuplicateCodeDemo/PurpleVC.xib
+++ b/DuplicateCodeDemo/PurpleVC.xib
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13142" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12042"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="PurpleVC" customModuleProvider="target">
+            <connections>
+                <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
+        </view>
+    </objects>
+</document>


### PR DESCRIPTION
This pull request introduces a new `PurpleVC` view controller to the `DuplicateCodeDemo` project. The changes include the implementation of the view controller in Swift and the corresponding XIB file for its user interface.

### New `PurpleVC` View Controller:

* **Implementation of `PurpleVC` class**: Added a new `PurpleVC` class in `PurpleVC.swift`. The class sets the background color to purple and includes two methods, `goToMainView` and `goToFirstView`, both of which navigate to a `RedViewController2` instance.

* **Addition of `PurpleVC.xib`**: Created a corresponding XIB file for `PurpleVC` to define its user interface. This file includes a placeholder for the view controller and sets up a basic view with a white background and safe area layout guides.